### PR TITLE
Fix PR number extraction for fork PRs

### DIFF
--- a/report/action.yml
+++ b/report/action.yml
@@ -37,9 +37,20 @@ runs:
     - name: Get PR number
       id: pr-number
       shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.github_token }}
       run: |
         # Extract PR number from the workflow_run event
+        # First try the pull_requests array
         PR_NUMBER=$(echo '${{ toJSON(github.event.workflow_run.pull_requests) }}' | jq -r '.[0].number')
+        
+        # If that's null, search for PR by head SHA (works for forks)
+        if [ "$PR_NUMBER" == "null" ] || [ -z "$PR_NUMBER" ]; then
+          echo "Pull requests array is empty, searching by head SHA..."
+          PR_NUMBER=$(gh pr list --repo ${{ github.repository }} --state open --json number,headRefOid \
+            --jq '.[] | select(.headRefOid == "${{ github.event.workflow_run.head_sha }}") | .number' | head -1)
+        fi
+        
         echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
         echo "PR number: $PR_NUMBER"
     


### PR DESCRIPTION
The `workflow_run.pull_requests` array is empty for fork PRs, causing PR number extraction to fail.

This PR adds a fallback that searches for the PR by head SHA using the gh CLI, which works for both internal and fork PRs.

Fixes: PR number: null
Fixes: No sticky comment posted on fork PRs