### PR TITLE
Rule updates

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -7,4 +7,4 @@ IgnoredScopes = tt, code
 [*.md]
 BasedOnStyles = Elastic
 
-TokenIgnores = % (.*), \*\*(.*)\*\*, , <(.*)>, {{(.*)}}
+TokenIgnores = % (.*), \*\*(.*), (.*)\*\*, \*\*(.*)\*\*, , <(.*)>, {{(.*)}}

--- a/styles/Elastic/Acronyms.yml
+++ b/styles/Elastic/Acronyms.yml
@@ -69,6 +69,7 @@ exceptions:
   - IoAs
   - IoCs
   - IoT
+  - IP
   - IR
   - ISV
   - IT
@@ -99,6 +100,7 @@ exceptions:
   - OEM
   - OOB
   - OOTB
+  - OS
   - OSS
   - OT
   - OTel
@@ -137,6 +139,7 @@ exceptions:
   - SVG
   - TBD
   - TCP
+  - TLS
   - TODO
   - TSVB
   - TTPs
@@ -148,6 +151,7 @@ exceptions:
   - UUID
   - VDI
   - VM
+  - VPN
   - VT
   - WDE
   - XDR

--- a/styles/Elastic/BritishSpellings.yml
+++ b/styles/Elastic/BritishSpellings.yml
@@ -14,9 +14,12 @@ swap:
   '\b(?:initialise)\b': initialize
   '\b(?:optimise)\b': optimize
   '\b(?:organise)\b': organize
+  '\b(?:prioritise)\b': prioritize
   '\b(?:realise)\b': realize
   '\b(?:recognise)\b': recognize
+  '\b(?:specialise)\b': specialize
   '\b(?:standardise)\b': standardize
+  '\b(?:utilise)\b': utilize 
   '\b(?:visualise)\b': visualize
   # -isation → -ization
   '\b(?:customisation)\b': customization
@@ -37,6 +40,11 @@ swap:
   '\b(?:catalogue)\b': catalog
   '\b(?:dialogue)\b': dialog
   '\b(?:epilogue)\b': epilog
+  # -st → /
+  '\b(?:amongst)\b': among
+  '\b(?:whilst)\b': while
   # misc
   '\b(?:grey)\b': gray
   '\b(?:programme)\b': program
+  '\b(?:towards)\b': toward
+  '\b(?:acknowledgement)\b': acknowledgment

--- a/styles/Elastic/Latinisms.yml
+++ b/styles/Elastic/Latinisms.yml
@@ -10,8 +10,9 @@ swap:
   '\b(?:ie|i\.e\.)[\s,]': that is
   'ad-hoc': if needed
   'ad hoc': if needed
-  '[\s]via[\s]': through
+  '[\s]via[\s]': using
   'vice versa': and the reverse
   '[\s]vs[\s|.]': versus
-  'etc': and so on
-  'etc\.': and so on
+  '\betc\b': and so on
+  '\betc\.\s': and so on
+  '\betc\.\)': and so on


### PR DESCRIPTION
More updates to Vale rules, including:

- Expanding `TokenIgnores` to ignore words starting or ending with `**` to avoid flagging UI elements
- Updating the "etc" entry in `Latinisms` to ensure it's not matched when it's part of a word (e.g. fetch)
- Additions to `BritishSpellings`
- Additions to `Acronyms` exceptions

Assisted by Cursor.