### PR TITLE
Remove 'extract' from wordiness replacements

### DIFF
--- a/styles/Elastic/Wordiness.yml
+++ b/styles/Elastic/Wordiness.yml
@@ -8,7 +8,7 @@ scope:
 action:
   name: replace
 swap:
-  (?:extract|take away|eliminate): remove
+  (?:take away|eliminate): remove
   (?:in order to|as a means to): to
   (?:inform|let know): tell
   (?:previous|prior) to: before


### PR DESCRIPTION
Suggest turning off this rule because `extract` is a common term when talking about transforming data or extract-transform-load processes. Can't think of many instances of people saying `extract` when they mean `remove` or `delete`.