### PR TITLE
Use regex for probable acronyms in capitalization exceptions

### DIFF
--- a/styles/Elastic/Capitalization.yml
+++ b/styles/Elastic/Capitalization.yml
@@ -10,7 +10,7 @@ indicators:
 # Allow some flexibility for edge cases
 threshold: 0.8
 exceptions:
-  - (?:[A-Z]{2,}) # Ignore acronyms
+  - (?:[A-Z_]{2,}) # Ignore acronyms
   - Advanced Settings
   - Agent
   - Analytics


### PR DESCRIPTION
Related to #58 https://github.com/elastic/vale-rules/commit/70070e9d347d6c05601dc8bbb0264ee69ed698b1

Use regex for probable acronyms in capitalization exceptions instead of listing a bunch of individual acronyms. There's a small possibility that this will let an ALL CAPS word through, but I think it's worth the risk to make it easier to contribute exceptions.

@theletterf let me know what you think about this approach.