### PR TITLE
Add more characters to `TokenIgnore` for custom anchor links

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -6,4 +6,4 @@ IgnoredScopes = tt, code, strong, b
 
 [*.md]
 BasedOnStyles = Elastic
-TokenIgnores = % (.*), \*\*(.*), (.*)\*\*, \*\*(.*)\*\*, , <(.*)>, {{(.*)}}, \s*\[[a-z0-9.-]+\]
+TokenIgnores = % (.*), \*\*(.*), (.*)\*\*, \*\*(.*)\*\*, , <(.*)>, {{(.*)}}, \s*\[[a-zA-Z0-9_.-]+\]


### PR DESCRIPTION
Related to https://github.com/elastic/vale-rules/issues/58 https://github.com/elastic/vale-rules/commit/70070e9d347d6c05601dc8bbb0264ee69ed698b1

[Custom anchor links](https://elastic.github.io/docs-builder/syntax/headings/#custom-anchor-links) in headings can also contain underscores and uppercase letters:

* Underscores are particularly common because by default [AsciiDoc uses underscores in autogenerated IDs](https://docs.asciidoctor.org/asciidoc/latest/sections/auto-ids/) and those were carried over during the migration. We didn't attempt to standardize without underscores because it was not worth the effort to also update all links.
* Though we probably want to discourage uppercase letters in custom anchor links, I don't think it's intuitive to prompt users to use sentence case in order to avoid uppercase letters in custom anchor links. If we feel strongly about not using uppercase letters, we should probably create a separate rule so we can use a more intuitive error message.