### PR TITLE
Add 'basic' to the list of synonyms for 'simple'

### DIFF
--- a/styles/Elastic/WordChoice.yml
+++ b/styles/Elastic/WordChoice.yml
@@ -31,7 +31,7 @@ swap:
   mute: "turn off, silence"
   sanity check: "review"
   see: "refer to (if it's a document), view (if it's a UI element)"
-  simple: "efficient"
+  simple: "efficient, basic"
   simply: "efficiently"
   skin-toned: "dark brown, cream, beige"
   terminate: "stop, exit"


### PR DESCRIPTION
Because `efficient` isn't the only viable synonym for `simple` :)

For example, imagine I have the text "a simple example":

- "a basic example" is a meaningful replacement 
- "an efficient example" is not