### PR TITLE
Change OxfordComma rule level from warning to suggestion

### DIFF
--- a/styles/Elastic/OxfordComma.yml
+++ b/styles/Elastic/OxfordComma.yml
@@ -1,8 +1,8 @@
 extends: existence
+level: suggestion
 message: "Use the Oxford comma in '%s'."
 link: https://www.elastic.co/docs/contribute-docs/style-guide/grammar-spelling#commas
 scope: sentence
-level: warning
 nonword: true
 tokens:
   - '(?:[^\s,]+,){1,} \w+ (?:and|or|nor|then) \w+[.?!]'


### PR DESCRIPTION
The Oxford comma is a stylistic preference rather than a strict grammar rule, so suggestion level is more appropriate than warning.