### PR TITLE
Updates FirstPerson.yml rule to remove `I` suggestions 

### DIFF
--- a/styles/Elastic/FirstPerson.yml
+++ b/styles/Elastic/FirstPerson.yml
@@ -1,13 +1,10 @@
 extends: existence
-message: "Avoid first-person pronouns such as '%s'."
+message: "Use caution when using first-person pronouns such as '%s.'"
 link: https://www.elastic.co/docs/contribute-docs/style-guide/grammar-spelling#use-singular-first-person-pronouns-sparingly-i-me-my-mine
 ignorecase: true
 level: suggestion
 nonword: true
 tokens:
-  - (?:^|\s)I\s
-  - (?:^|\s)I,\s
-  - \bI'm\b
   - \bme\b
   - \bmy\b
   - \bmine\b


### PR DESCRIPTION
Contributes to #103 by removing suggestions when "`I`" first pronouns exist. 
>[!NOTE]
We can further examine later if removing the remainder of first pronouns `me, my, mine` is needed. However, the general rule of not using first pronouns will remain in the style guide. 