### PR TITLE
Fix false positives in Latinisms, WordChoice, and Wordiness rules

### DIFF
--- a/styles/Elastic/Latinisms.yml
+++ b/styles/Elastic/Latinisms.yml
@@ -13,4 +13,4 @@ swap:
   '\bvia\b': using
   '\bvice versa\b': and the reverse
   '\bvs\b': versus
-  '\betc\b': and so on
+  '(?<!/)\betc\b': and so on

--- a/styles/Elastic/WordChoice.yml
+++ b/styles/Elastic/WordChoice.yml
@@ -29,7 +29,7 @@ swap:
   may: "can, might"
   mute: "turn off, silence"
   sanity check: "review"
-  see: "refer to (if it's a document), view (if it's a UI element)"
+  '\bsee(?=\s+(?:the|our|this)\b|\s+\[)': "refer to (if it's a document), view (if it's a UI element)"
   simple: "efficient, basic"
   simply: "efficiently"
   skin-toned: "dark brown, cream, beige"

--- a/styles/Elastic/Wordiness.yml
+++ b/styles/Elastic/Wordiness.yml
@@ -80,7 +80,7 @@ swap:
   in a careful manner: carefully
   in a thoughtful manner: thoughtfully
   in a timely manner: timely
-  in addition: also
+  in addition(?!\s+to\b): also
   in an effort to: to
   in between: between
   in lieu of: instead of


### PR DESCRIPTION
## Summary

- **Latinisms**: adds a negative lookbehind (`(?<!/)\betc\b`) so Unix filesystem paths like `/etc/nginx/conf` are no longer flagged as the Latin abbreviation "etc." — both in inline code and plain prose.
- **WordChoice**: narrows the `see` pattern to only catch cross-reference usage (when followed by `the`, `our`, `this`, or a Markdown link bracket). Observational uses like "you can see:" no longer fire.
- **Wordiness**: adds a negative lookahead (`(?!\s+to\b)`) so "in addition to [object]" is not flagged, since "also" is not a grammatically valid replacement when a `to` clause follows.

All three were identified as false positives from real user feedback on [`elastic/integrations#17410`](https://github.com/elastic/integrations/pull/17410) and internal reports.

## Test plan

- [x] Ran `vale --config .vale.ini --no-global test-all-rules.md` — all expected rules still fire, no new false positives.
- [x] Ran against `sample-violations.md` — violations detected as expected.
- [x] Ran against `clean-doc.md` — zero issues.
- [x] Verified `/etc/` paths (inline code and bare prose) no longer trigger `Latinisms`.
- [x] Verified "you can see:" no longer triggers `WordChoice`.
- [x] Verified "in addition to these, ..." no longer triggers `Wordiness`.

Made with [Cursor](https://cursor.com)