### PR TITLE
Add negation pattern support to include-paths

### DIFF
--- a/.github/test-fixtures/team-a/excluded/doc.md
+++ b/.github/test-fixtures/team-a/excluded/doc.md
@@ -1,0 +1,5 @@
+# Team A excluded documentation
+
+This is a FAQ document with a HTML parser.
+
+We need to optimise the behaviour.

--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -214,12 +214,60 @@ jobs:
             echo "✓ team-b files were correctly filtered out"
           fi
 
+  # Test negation patterns in include-paths
+  test-include-paths-negation:
+    name: Test include_paths negation
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Run lint with negation pattern
+        id: lint-negation
+        uses: ./lint
+        with:
+          files: .github/test-fixtures/team-a/doc.md .github/test-fixtures/team-a/excluded/doc.md
+          include-paths: |
+            .github/test-fixtures/team-a/**
+            !.github/test-fixtures/team-a/excluded/**
+          fail_on_error: 'false'
+          use_local_styles: 'true'
+          disable_telemetry: 'true'
+          upload_artifact: 'false'
+          debug: 'true'
+
+      - name: Verify negation filtering worked
+        run: |
+          if [ ! -f vale_report.md ]; then
+            echo "::error::vale_report.md was not generated"
+            exit 1
+          fi
+
+          # team-a/doc.md should be included
+          if grep -q "team-a/doc.md" vale_report.md; then
+            echo "✓ team-a/doc.md was linted"
+          else
+            echo "::error::team-a/doc.md should have been linted"
+            exit 1
+          fi
+
+          # team-a/excluded/doc.md should be excluded by negation
+          if grep -q "team-a/excluded" vale_report.md; then
+            echo "::error::team-a/excluded/doc.md should have been excluded by negation"
+            exit 1
+          else
+            echo "✓ team-a/excluded/doc.md was correctly excluded by negation"
+          fi
+
   # This job runs after all matrix jobs complete to upload a single artifact
   # that the report action can download
   upload-results:
     name: Upload combined results
     runs-on: ubuntu-latest
-    needs: [test-lint, test-clean-file, test-include-paths]
+    needs: [test-lint, test-clean-file, test-include-paths, test-include-paths-negation]
     if: always()
 
     steps:

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ The lint action supports these inputs:
 | Input | Description | Default |
 |-------|-------------|---------|
 | `files` | Files or directories to lint (space-separated). If not provided, lints changed files in PR. | `''` |
-| `include-paths` | Paths to include for linting (multi-line or space-separated). Supports glob patterns. Only files matching these paths will be linted. | `''` |
+| `include-paths` | Paths to include for linting (multi-line or space-separated). Supports glob patterns and `!` negation to exclude paths. Only files matching these paths will be linted. | `''` |
 | `fail_on_error` | Fail the action if Vale finds error-level issues. | `'false'` |
 | `vale_version` | Vale version to install. | `'latest'` |
 | `debug` | Enable debug output. | `'false'` |
@@ -90,6 +90,17 @@ With glob patterns:
     include-paths: |
       docs/guides/**
       docs/reference/**
+```
+
+With negation patterns to exclude specific subdirectories:
+
+```yaml
+- name: Run Vale Linter
+  uses: elastic/vale-rules/lint@main
+  with:
+    include-paths: |
+      docs/reference/**
+      !docs/reference/query-languages/esql/**
 ```
 
 Space-separated format is also supported: `include-paths: "docs/team-a docs/team-b"`

--- a/lint/action.yml
+++ b/lint/action.yml
@@ -12,7 +12,7 @@ inputs:
     required: false
     default: ''
   include-paths:
-    description: 'Paths to include for linting. Supports glob patterns. Can be space-separated or multi-line. Only files matching these paths will be linted.'
+    description: 'Paths to include for linting. Supports glob patterns and ! negation to exclude paths. Can be space-separated or multi-line. Only files matching these paths will be linted.'
     required: false
     default: ''
   fail_on_error:

--- a/lint/path_filter.py
+++ b/lint/path_filter.py
@@ -24,39 +24,58 @@ import os
 import sys
 
 
-def parse_patterns(include_paths: str) -> list[str]:
-    """Parse include-paths input (handles multi-line and space-separated)."""
-    patterns = []
+def parse_patterns(include_paths: str) -> tuple[list[str], list[str]]:
+    """Parse include-paths input (handles multi-line and space-separated).
+
+    Patterns prefixed with ``!`` are treated as exclusions. Returns a tuple
+    of ``(include_patterns, exclude_patterns)`` with the ``!`` prefix stripped
+    from exclusion entries.
+    """
+    includes = []
+    excludes = []
     for line in include_paths.split('\n'):
         for pattern in line.split():
             pattern = pattern.strip().rstrip('/')
-            if pattern:
-                patterns.append(pattern)
-    return patterns
+            if not pattern:
+                continue
+            if pattern.startswith('!'):
+                negated = pattern[1:].rstrip('/')
+                if negated:
+                    excludes.append(negated)
+            else:
+                includes.append(pattern)
+    return includes, excludes
 
 
 def matches_pattern(file: str, pattern: str) -> bool:
     """Check if a file matches a pattern (glob or prefix)."""
-    # Use fnmatch for glob pattern matching
     if fnmatch.fnmatch(file, pattern):
         return True
-    # Simple prefix matching for directory patterns
     if file.startswith(pattern + '/'):
         return True
     return False
 
 
-def filter_files(files: list[str], patterns: list[str], debug: bool = False) -> list[str]:
-    """Filter files to only those matching any pattern."""
+def filter_files(
+    files: list[str],
+    includes: list[str],
+    excludes: list[str] | None = None,
+    debug: bool = False,
+) -> list[str]:
+    """Filter files to only those matching an include pattern and no exclude pattern."""
+    if excludes is None:
+        excludes = []
     filtered = []
     for file in files:
-        matched = any(matches_pattern(file, p) for p in patterns)
-        if matched:
+        matched = any(matches_pattern(file, p) for p in includes)
+        excluded = any(matches_pattern(file, p) for p in excludes)
+        if matched and not excluded:
             if debug:
                 print(f"::debug::File '{file}' matched", file=sys.stderr)
             filtered.append(file)
         elif debug:
-            print(f"::debug::File '{file}' excluded", file=sys.stderr)
+            reason = 'excluded by negation' if matched and excluded else 'no match'
+            print(f"::debug::File '{file}' excluded ({reason})", file=sys.stderr)
     return filtered
 
 
@@ -72,14 +91,16 @@ def main() -> int:
     include_paths = os.environ.get('INCLUDE_PATHS', '')
     debug = os.environ.get('DEBUG', 'false').lower() == 'true'
     
-    patterns = parse_patterns(include_paths)
+    includes, excludes = parse_patterns(include_paths)
     
-    if not patterns:
-        print('No patterns provided')
+    if not includes:
+        print('No include patterns provided')
         return 0
     
     if debug:
-        print(f'::debug::Patterns: {patterns}', file=sys.stderr)
+        print(f'::debug::Include patterns: {includes}', file=sys.stderr)
+        if excludes:
+            print(f'::debug::Exclude patterns: {excludes}', file=sys.stderr)
     
     # Read files to lint
     try:
@@ -89,10 +110,9 @@ def main() -> int:
         print('No files_to_lint.txt found')
         return 0
     
-    print(f'Filtering {len(files)} files against {len(patterns)} patterns...')
+    print(f'Filtering {len(files)} files against {len(includes)} include and {len(excludes)} exclude patterns...')
     
-    # Filter files
-    filtered = filter_files(files, patterns, debug)
+    filtered = filter_files(files, includes, excludes, debug)
     
     # Write results
     if filtered:

--- a/lint/test_path_filter.py
+++ b/lint/test_path_filter.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python3
+
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+"""Tests for path_filter.py."""
+
+import unittest
+
+from path_filter import filter_files, matches_pattern, parse_patterns
+
+
+class TestParsePatterns(unittest.TestCase):
+    def test_simple_paths(self):
+        includes, excludes = parse_patterns("docs/team-a docs/team-b")
+        assert includes == ["docs/team-a", "docs/team-b"]
+        assert excludes == []
+
+    def test_multiline(self):
+        includes, excludes = parse_patterns("docs/team-a\ndocs/team-b")
+        assert includes == ["docs/team-a", "docs/team-b"]
+        assert excludes == []
+
+    def test_negation(self):
+        includes, excludes = parse_patterns(
+            "docs/reference/**\n!docs/reference/query-languages/esql/**"
+        )
+        assert includes == ["docs/reference/**"]
+        assert excludes == ["docs/reference/query-languages/esql/**"]
+
+    def test_mixed_negation_and_includes(self):
+        includes, excludes = parse_patterns(
+            "docs/** !docs/internal/** src/**"
+        )
+        assert includes == ["docs/**", "src/**"]
+        assert excludes == ["docs/internal/**"]
+
+    def test_trailing_slashes_stripped(self):
+        includes, excludes = parse_patterns("docs/team-a/ !docs/team-b/")
+        assert includes == ["docs/team-a"]
+        assert excludes == ["docs/team-b"]
+
+    def test_empty_input(self):
+        includes, excludes = parse_patterns("")
+        assert includes == []
+        assert excludes == []
+
+    def test_bare_negation_ignored(self):
+        includes, excludes = parse_patterns("docs/** !")
+        assert includes == ["docs/**"]
+        assert excludes == []
+
+
+class TestMatchesPattern(unittest.TestCase):
+    def test_glob_match(self):
+        assert matches_pattern("docs/reference/api.md", "docs/reference/**")
+
+    def test_prefix_match(self):
+        assert matches_pattern("docs/team-a/guide.md", "docs/team-a")
+
+    def test_no_match(self):
+        assert not matches_pattern("src/main.py", "docs/**")
+
+    def test_exact_match(self):
+        assert matches_pattern("README.md", "README.md")
+
+
+class TestFilterFiles(unittest.TestCase):
+    FILES = [
+        "docs/reference/api.md",
+        "docs/reference/setup.md",
+        "docs/reference/query-languages/esql/overview.md",
+        "docs/reference/query-languages/esql/syntax.md",
+        "docs/reference/query-languages/kql/overview.md",
+        "docs/guides/getting-started.md",
+        "src/main.py",
+    ]
+
+    def test_include_only(self):
+        result = filter_files(self.FILES, ["docs/reference/**"])
+        assert result == [
+            "docs/reference/api.md",
+            "docs/reference/setup.md",
+            "docs/reference/query-languages/esql/overview.md",
+            "docs/reference/query-languages/esql/syntax.md",
+            "docs/reference/query-languages/kql/overview.md",
+        ]
+
+    def test_include_with_exclusion(self):
+        result = filter_files(
+            self.FILES,
+            ["docs/reference/**"],
+            ["docs/reference/query-languages/esql/**"],
+        )
+        assert result == [
+            "docs/reference/api.md",
+            "docs/reference/setup.md",
+            "docs/reference/query-languages/kql/overview.md",
+        ]
+
+    def test_multiple_excludes(self):
+        result = filter_files(
+            self.FILES,
+            ["docs/**"],
+            ["docs/reference/query-languages/esql/**", "docs/guides/**"],
+        )
+        assert result == [
+            "docs/reference/api.md",
+            "docs/reference/setup.md",
+            "docs/reference/query-languages/kql/overview.md",
+        ]
+
+    def test_exclude_without_includes_returns_nothing(self):
+        result = filter_files(self.FILES, [], ["docs/**"])
+        assert result == []
+
+    def test_no_excludes(self):
+        result = filter_files(self.FILES, ["docs/guides/**"], [])
+        assert result == ["docs/guides/getting-started.md"]
+
+    def test_exclude_none(self):
+        result = filter_files(self.FILES, ["docs/guides/**"])
+        assert result == ["docs/guides/getting-started.md"]
+
+    def test_prefix_include_with_glob_exclude(self):
+        result = filter_files(
+            self.FILES,
+            ["docs/reference"],
+            ["docs/reference/query-languages/**"],
+        )
+        assert result == [
+            "docs/reference/api.md",
+            "docs/reference/setup.md",
+        ]
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `!` prefix support in the `include-paths` action input to exclude specific paths from linting. A file is included only if it matches an include pattern **and** does not match any exclude pattern.
- This allows carving out subdirectories from a broader include, e.g. `docs/reference/**` with `!docs/reference/query-languages/esql/**`.

## Changes

- **`lint/path_filter.py`** — `parse_patterns` now splits patterns into includes/excludes based on the `!` prefix. `filter_files` applies both lists.
- **`lint/action.yml`** — Updated input description.
- **`README.md`** — Documented the negation syntax with an example.
- **`lint/test_path_filter.py`** (new) — 18 unit tests covering parsing, matching, filtering, negation, and edge cases.
- **`.github/workflows/test-lint.yml`** — Added `test-include-paths-negation` CI job.
- **`.github/test-fixtures/team-a/excluded/doc.md`** (new) — Test fixture for negation CI test.

## Test plan

- [x] All 18 unit tests pass locally (`python3 lint/test_path_filter.py`).
- [ ] CI `test-include-paths-negation` job passes.
- [ ] Existing `test-include-paths` job still passes (no regressions).


Made with [Cursor](https://cursor.com)