### PR TITLE
Filter non-markdown files from explicit file input

### DIFF
--- a/lint/action.yml
+++ b/lint/action.yml
@@ -238,14 +238,14 @@ runs:
         if [ -n "${{ github.event.pull_request.base.sha }}" ]; then
           echo "Detecting changed files in PR..."
           git diff --name-only --diff-filter=d ${{ github.event.pull_request.base.sha }}...${{ github.event.pull_request.head.sha }} \
-            | grep -E '\.(md|adoc)$' > changed_files.txt || echo "No markdown/adoc files changed"
+            | grep -E '\.md$' > changed_files.txt || echo "No markdown files changed"
 
           if [ -s changed_files.txt ]; then
             echo "Found changed files:"
             cat changed_files.txt
             echo "has_changes=true" >> $GITHUB_OUTPUT
           else
-            echo "No markdown or adoc files changed in this PR"
+            echo "No markdown files changed in this PR"
             echo "has_changes=false" >> $GITHUB_OUTPUT
           fi
         else
@@ -261,8 +261,13 @@ runs:
       run: |
         if [ -n "${INPUT_FILES}" ]; then
           echo "Using provided files: ${INPUT_FILES}"
-          echo "${INPUT_FILES}" | tr ' ' '\n' > files_to_lint.txt
-          echo "has_files=true" >> $GITHUB_OUTPUT
+          echo "${INPUT_FILES}" | tr ' ' '\n' | grep -E '\.md$' > files_to_lint.txt || true
+          if [ -s files_to_lint.txt ]; then
+            echo "has_files=true" >> $GITHUB_OUTPUT
+          else
+            echo "No markdown files in provided file list"
+            echo "has_files=false" >> $GITHUB_OUTPUT
+          fi
         elif [ "${{ steps.changed-files.outputs.has_changes }}" == "true" ]; then
           echo "Using changed files from PR"
           cp changed_files.txt files_to_lint.txt


### PR DESCRIPTION
## Summary
- When callers pass files via the `files` input (e.g., YAML changelog files), the action processed them without filtering by extension
- This caused `git diff` to fail with exit code 128 in blobless clones (like the `elastic/cloud` repo), crashing the entire Vale step
- Now both the explicit `files` input path and the auto-detected PR files path filter to `.md` only, matching Vale's `[*.md]` config scope
- Also removed `.adoc` from the auto-detection filter since Vale is only configured for markdown

## Context
Triggered by: elastic/cloud#152482 — a PR that only changed `.yaml` release note files, but Vale crashed trying to `git diff` them

## Test plan
- [ ] Verify Vale skips cleanly when only non-markdown files are passed via `files` input
- [ ] Verify Vale still runs normally when markdown files are passed via `files` input
- [ ] Verify auto-detected PR file filtering still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)