### PR TITLE
Handle large Vale file sets safely

### DIFF
--- a/.github/workflows/test-lint.yml
+++ b/.github/workflows/test-lint.yml
@@ -166,6 +166,10 @@ jobs:
         working-directory: lint
         run: python3 -m unittest test_path_filter -v
 
+      - name: Run run_vale tests
+        working-directory: lint
+        run: python3 -m unittest test_run_vale -v
+
       - name: Run render_report tests
         working-directory: report
         run: python3 -m unittest test_render_report -v
@@ -376,12 +380,85 @@ jobs:
             exit 1
           fi
 
+  test-max-files-skip:
+    name: Test max_files skip
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Create many markdown files
+        id: many-files
+        run: |
+          mkdir -p .github/test-fixtures/many-files
+          FILES=""
+          for i in $(seq 1 31); do
+            file=".github/test-fixtures/many-files/doc-$i.md"
+            cp .github/test-fixtures/clean-doc.md "$file"
+            FILES="$FILES $file"
+          done
+          echo "files=${FILES# }" >> "$GITHUB_OUTPUT"
+
+      - name: Run lint with max_files threshold
+        id: lint-max-files
+        uses: ./lint
+        with:
+          files: ${{ steps.many-files.outputs.files }}
+          max_files: '30'
+          fail_on_error: 'true'
+          use_local_styles: 'true'
+          disable_telemetry: 'true'
+          upload_artifact: 'false'
+          debug: 'true'
+
+      - name: Verify lint was skipped
+        run: |
+          if [ ! -f vale_results.json ]; then
+            echo "::error::vale_results.json was not generated"
+            exit 1
+          fi
+
+          python3 - <<'PY'
+          import json
+
+          with open("vale_results.json", encoding="utf-8") as f:
+              data = json.load(f)
+
+          skipped = data.get("skipped")
+          assert skipped is not None, "Expected skipped payload"
+          assert skipped["reason"] == "too_many_files", skipped
+          assert skipped["file_count"] == 31, skipped
+          assert skipped["max_files"] == 30, skipped
+          assert data["summary"] == {"errors": 0, "warnings": 0, "suggestions": 0}, data["summary"]
+          assert data["issues"] == [], data["issues"]
+          print("OK: lint skipped when file count exceeded threshold")
+          PY
+
+      - name: Verify skip report was generated
+        run: |
+          if [ ! -f vale_report.md ]; then
+            echo "::error::vale_report.md was not generated"
+            exit 1
+          fi
+
+          if grep -q "Skipped" vale_report.md && grep -q "31 files" vale_report.md; then
+            echo "✓ Skip report rendered as expected"
+          else
+            echo "::error::Skip report missing expected content"
+            cat vale_report.md
+            exit 1
+          fi
+
   # This job runs after all matrix jobs complete to upload a single artifact
   # that the report action can download
   upload-results:
     name: Upload combined results
     runs-on: ubuntu-latest
-    needs: [test-lint, test-clean-file, test-vale-paths, test-vale-paths-negation, test-repo-override]
+    needs: [test-lint, test-clean-file, test-vale-paths, test-vale-paths-negation, test-repo-override, test-max-files-skip]
     if: always() && needs.test-lint.result == 'success'
 
     steps:

--- a/README.md
+++ b/README.md
@@ -85,6 +85,7 @@ The lint action supports these inputs:
 | `debug` | Enable debug output. | `'false'` |
 | `upload_artifact` | Upload Vale results as a workflow artifact. | `'true'` |
 | `artifact_name` | Name for the uploaded artifact. | `'vale-results'` |
+| `max_files` | Skip Vale when the number of files to lint exceeds this threshold. Set to `0` to disable skipping. | `'30'` |
 
 ### Action outputs
 
@@ -170,6 +171,8 @@ jobs:
 ```
 
 This two-workflow approach ensures fork PRs are linted safely while still posting results as PR comments.
+
+If a PR exceeds the `max_files` threshold, the lint action skips Vale and posts a report that explains why linting did not run.
 
 Refer to [ACTION_USAGE.md](ACTION_USAGE.md) for detailed documentation and examples.
 

--- a/lint/action.yml
+++ b/lint/action.yml
@@ -51,6 +51,10 @@ inputs:
     description: 'Name for the uploaded artifact (only used when upload_artifact is true)'
     required: false
     default: 'vale-results'
+  max_files:
+    description: 'Skip Vale when the number of files to lint exceeds this threshold. Set to 0 to disable skipping.'
+    required: false
+    default: '30'
 outputs:
   artifact_uploaded:
     description: 'Whether Vale results were uploaded as an artifact'
@@ -380,9 +384,38 @@ runs:
           echo "has_files=false" >> $GITHUB_OUTPUT
         fi
 
+    - name: Check max file threshold
+      id: file-threshold
+      if: steps.final-files-check.outputs.has_files == 'true'
+      shell: bash
+      env:
+        MAX_FILES: ${{ inputs.max_files }}
+      run: |
+        if ! [[ "$MAX_FILES" =~ ^[0-9]+$ ]]; then
+          echo "::error::max_files must be a non-negative integer, got '$MAX_FILES'"
+          exit 1
+        fi
+
+        sort -u files_to_lint.txt > files_to_lint.sorted
+        mv files_to_lint.sorted files_to_lint.txt
+
+        FILE_COUNT=$(wc -l < files_to_lint.txt | tr -d ' ')
+        echo "file_count=$FILE_COUNT" >> $GITHUB_OUTPUT
+
+        if [ "$MAX_FILES" -eq 0 ]; then
+          echo "skip_lint=false" >> $GITHUB_OUTPUT
+          echo "Max file threshold disabled"
+        elif [ "$FILE_COUNT" -gt "$MAX_FILES" ]; then
+          echo "skip_lint=true" >> $GITHUB_OUTPUT
+          echo "::notice::Skipping Vale because $FILE_COUNT files exceed the max_files threshold of $MAX_FILES"
+        else
+          echo "skip_lint=false" >> $GITHUB_OUTPUT
+          echo "Linting $FILE_COUNT file(s), within max_files threshold of $MAX_FILES"
+        fi
+
     - name: Setup temp directory
       id: setup-temp
-      if: steps.final-files-check.outputs.has_files == 'true'
+      if: steps.final-files-check.outputs.has_files == 'true' && steps.file-threshold.outputs.skip_lint != 'true'
       shell: bash
       env:
         DEBUG: ${{ inputs.debug }}
@@ -398,7 +431,7 @@ runs:
 
     - name: Get modified line ranges
       id: modified-lines
-      if: steps.final-files-check.outputs.has_files == 'true' && github.event.pull_request.number != ''
+      if: steps.final-files-check.outputs.has_files == 'true' && steps.file-threshold.outputs.skip_lint != 'true' && github.event.pull_request.number != ''
       shell: bash
       env:
         TEMP_DIR: ${{ steps.setup-temp.outputs.temp_dir }}
@@ -448,7 +481,7 @@ runs:
 
     - name: Run Vale and generate report
       id: vale-report
-      if: steps.final-files-check.outputs.has_files == 'true'
+      if: steps.final-files-check.outputs.has_files == 'true' && steps.file-threshold.outputs.skip_lint != 'true'
       shell: bash
       env:
         GITHUB_REPOSITORY: ${{ github.repository }}
@@ -479,14 +512,17 @@ runs:
           exit 1
         fi
 
-        # Run Vale with JSON output on all files, with a 5-minute timeout to prevent hangs
-        # Capture stderr separately to avoid corrupting JSON output
+        # Run Vale in bounded batches to avoid "argument list too long" errors
+        # when a PR touches many files. Capture stderr separately to avoid
+        # corrupting JSON output.
         VALE_STDERR=$(mktemp)
         VALE_EXIT=0
 
-        # Read files into an array to handle filenames safely
-        mapfile -t VALE_FILES < files_to_lint.txt
-        timeout 300 vale --config=.vale.ini.temp --output=JSON "${VALE_FILES[@]}" > vale_output.json 2>"$VALE_STDERR" || VALE_EXIT=$?
+        python3 ${{ github.action_path }}/run_vale.py \
+          --config .vale.ini.temp \
+          --input files_to_lint.txt \
+          --output vale_output.json \
+          --stderr "$VALE_STDERR" || VALE_EXIT=$?
 
         if [ $VALE_EXIT -eq 124 ]; then
           echo "::error::Vale timed out after 5 minutes"
@@ -571,6 +607,56 @@ runs:
           echo "error_count=0" >> $GITHUB_OUTPUT
         fi
 
+    - name: Write skip report
+      if: steps.final-files-check.outputs.has_files == 'true' && steps.file-threshold.outputs.skip_lint == 'true'
+      shell: bash
+      env:
+        FILE_COUNT: ${{ steps.file-threshold.outputs.file_count }}
+        MAX_FILES: ${{ inputs.max_files }}
+      run: |
+        python3 - <<'PY'
+        import json
+        import os
+
+        file_count = int(os.environ["FILE_COUNT"])
+        max_files = int(os.environ["MAX_FILES"])
+
+        report = {
+          "summary": {
+            "errors": 0,
+            "warnings": 0,
+            "suggestions": 0,
+          },
+          "issues": [],
+          "skipped": {
+            "reason": "too_many_files",
+            "file_count": file_count,
+            "max_files": max_files,
+          },
+        }
+
+        with open("vale_results.json", "w", encoding="utf-8") as f:
+          json.dump(report, f)
+        PY
+
+        cat > vale_report.md <<EOF
+        ## ⚪ Vale Linting Results
+
+        **Skipped:** Vale did not run because this PR touched ${FILE_COUNT} files, which is more than the configured limit of ${MAX_FILES}.
+
+        ---
+
+        The Vale linter checks documentation changes against the [Elastic Docs style guide](https://www.elastic.co/docs/contribute-docs/style-guide).
+
+        To use Vale locally or report issues, refer to [Elastic style guide for Vale](https://www.elastic.co/docs/contribute-docs/vale-linter).
+        EOF
+
+        cat > issue_counts.txt <<EOF
+        errors=0
+        warnings=0
+        suggestions=0
+        EOF
+
     - name: Write Job Summary
       if: always() && steps.final-files-check.outputs.has_files == 'true'
       shell: bash
@@ -605,7 +691,7 @@ runs:
         fi
 
     - name: Fail on errors
-      if: inputs.fail_on_error == 'true' && steps.vale-report.outputs.error_count != '0'
+      if: inputs.fail_on_error == 'true' && steps.file-threshold.outputs.skip_lint != 'true' && steps.vale-report.outputs.error_count != '0'
       shell: bash
       run: |
         echo "❌ Vale found ${{ steps.vale-report.outputs.error_count }} error-level issue(s)"

--- a/lint/run_vale.py
+++ b/lint/run_vale.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+"""
+Run Vale in bounded batches and merge JSON output.
+
+This avoids "argument list too long" failures when a PR touches many files.
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+DEFAULT_MAX_FILES_PER_BATCH = 50
+DEFAULT_MAX_ARG_CHARS = 16000
+
+
+def load_files(path: str) -> list[str]:
+    """Load newline-delimited file paths, preserving order and uniqueness."""
+    seen: set[str] = set()
+    files: list[str] = []
+    for raw_line in Path(path).read_text(encoding="utf-8").splitlines():
+        file_path = raw_line.strip()
+        if not file_path or file_path in seen:
+            continue
+        seen.add(file_path)
+        files.append(file_path)
+    return files
+
+
+def chunk_files(
+    files: list[str],
+    *,
+    max_files_per_batch: int = DEFAULT_MAX_FILES_PER_BATCH,
+    max_arg_chars: int = DEFAULT_MAX_ARG_CHARS,
+) -> list[list[str]]:
+    """Split file paths into batches with bounded size and argv length."""
+    if max_files_per_batch < 1:
+        raise ValueError("max_files_per_batch must be at least 1")
+    if max_arg_chars < 1:
+        raise ValueError("max_arg_chars must be at least 1")
+
+    batches: list[list[str]] = []
+    current: list[str] = []
+    current_chars = 0
+
+    for file_path in files:
+        file_chars = len(file_path) + 1
+        if current and (
+            len(current) >= max_files_per_batch
+            or current_chars + file_chars > max_arg_chars
+        ):
+            batches.append(current)
+            current = []
+            current_chars = 0
+
+        current.append(file_path)
+        current_chars += file_chars
+
+    if current:
+        batches.append(current)
+
+    return batches
+
+
+def merge_vale_output(merged: dict, batch_data: dict) -> dict:
+    """Merge Vale's per-file JSON dictionaries across batches."""
+    for path, issues in batch_data.items():
+        merged.setdefault(path, [])
+        merged[path].extend(issues)
+    return merged
+
+
+def run_batch(
+    vale_bin: str,
+    config: str,
+    batch: list[str],
+    timeout_seconds: int,
+) -> subprocess.CompletedProcess[str]:
+    """Run Vale on one batch and capture JSON output."""
+    command = [vale_bin, f"--config={config}", "--output=JSON", *batch]
+    return subprocess.run(
+        command,
+        capture_output=True,
+        text=True,
+        timeout=timeout_seconds,
+        check=False,
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Run Vale in bounded batches")
+    parser.add_argument("--config", required=True, help="Path to Vale config")
+    parser.add_argument("--input", required=True, help="Path to files_to_lint.txt")
+    parser.add_argument("--output", required=True, help="Path to combined JSON output")
+    parser.add_argument("--stderr", required=True, help="Path to captured stderr output")
+    parser.add_argument("--vale-bin", default="vale", help="Vale executable to run")
+    parser.add_argument("--timeout-seconds", type=int, default=300, help="Per-batch timeout in seconds")
+    parser.add_argument("--max-files-per-batch", type=int, default=DEFAULT_MAX_FILES_PER_BATCH)
+    parser.add_argument("--max-arg-chars", type=int, default=DEFAULT_MAX_ARG_CHARS)
+    args = parser.parse_args()
+
+    files = load_files(args.input)
+    batches = chunk_files(
+        files,
+        max_files_per_batch=args.max_files_per_batch,
+        max_arg_chars=args.max_arg_chars,
+    )
+
+    merged_output: dict = {}
+    stderr_chunks: list[str] = []
+    highest_exit_code = 0
+
+    for index, batch in enumerate(batches, start=1):
+        print(
+            f"Running Vale batch {index}/{len(batches)} on {len(batch)} file(s)",
+            file=sys.stderr,
+        )
+        try:
+            result = run_batch(args.vale_bin, args.config, batch, args.timeout_seconds)
+        except subprocess.TimeoutExpired:
+            Path(args.stderr).write_text(
+                f"Vale timed out after {args.timeout_seconds} seconds\n",
+                encoding="utf-8",
+            )
+            return 124
+
+        highest_exit_code = max(highest_exit_code, result.returncode)
+        if result.stderr:
+            stderr_chunks.append(result.stderr)
+
+        stdout = result.stdout.strip()
+        if not stdout:
+            continue
+
+        try:
+            batch_data = json.loads(stdout)
+        except json.JSONDecodeError as exc:
+            stderr_chunks.append(
+                f"Failed to parse Vale JSON for batch {index}: {exc}\n{result.stdout}\n"
+            )
+            Path(args.stderr).write_text("".join(stderr_chunks), encoding="utf-8")
+            return 2
+
+        if not isinstance(batch_data, dict):
+            stderr_chunks.append(
+                f"Vale JSON for batch {index} was not an object: {type(batch_data).__name__}\n"
+            )
+            Path(args.stderr).write_text("".join(stderr_chunks), encoding="utf-8")
+            return 2
+
+        merge_vale_output(merged_output, batch_data)
+
+    Path(args.output).write_text(
+        json.dumps(merged_output, ensure_ascii=True),
+        encoding="utf-8",
+    )
+    Path(args.stderr).write_text("".join(stderr_chunks), encoding="utf-8")
+    return highest_exit_code
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lint/test_run_vale.py
+++ b/lint/test_run_vale.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+
+# Licensed to Elasticsearch B.V under one or more agreements.
+# Elasticsearch B.V licenses this file to you under the Apache 2.0 License.
+# See the LICENSE file in the project root for more information
+
+"""Tests for lint/run_vale.py."""
+
+import tempfile
+import unittest
+from pathlib import Path
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+import run_vale
+
+
+class TestLoadFiles(unittest.TestCase):
+
+    def test_load_files_deduplicates_and_preserves_order(self):
+        with tempfile.NamedTemporaryFile(mode="w", delete=False) as tmp:
+            tmp.write("a.md\n\nb.md\na.md\n")
+            tmp_path = tmp.name
+        try:
+            self.assertEqual(run_vale.load_files(tmp_path), ["a.md", "b.md"])
+        finally:
+            Path(tmp_path).unlink()
+
+
+class TestChunkFiles(unittest.TestCase):
+
+    def test_chunks_by_max_files(self):
+        files = [f"doc-{i}.md" for i in range(5)]
+        chunks = run_vale.chunk_files(files, max_files_per_batch=2, max_arg_chars=1000)
+        self.assertEqual(chunks, [["doc-0.md", "doc-1.md"], ["doc-2.md", "doc-3.md"], ["doc-4.md"]])
+
+    def test_chunks_by_arg_length(self):
+        files = ["a" * 8, "b" * 8, "c" * 8]
+        chunks = run_vale.chunk_files(files, max_files_per_batch=10, max_arg_chars=18)
+        self.assertEqual(chunks, [["a" * 8, "b" * 8], ["c" * 8]])
+
+    def test_rejects_invalid_limits(self):
+        with self.assertRaises(ValueError):
+            run_vale.chunk_files(["a.md"], max_files_per_batch=0)
+        with self.assertRaises(ValueError):
+            run_vale.chunk_files(["a.md"], max_arg_chars=0)
+
+
+class TestMergeValeOutput(unittest.TestCase):
+
+    def test_merges_issue_lists_per_file(self):
+        merged = {"docs/a.md": [{"Check": "One"}]}
+        batch = {
+            "docs/a.md": [{"Check": "Two"}],
+            "docs/b.md": [{"Check": "Three"}],
+        }
+        result = run_vale.merge_vale_output(merged, batch)
+        self.assertEqual(
+            result,
+            {
+                "docs/a.md": [{"Check": "One"}, {"Check": "Two"}],
+                "docs/b.md": [{"Check": "Three"}],
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/report/render_report.py
+++ b/report/render_report.py
@@ -32,6 +32,7 @@ MAX_RULE_LEN = 128
 MAX_ISSUES = 1000
 ALLOWED_SEVERITIES = frozenset({"error", "warning", "suggestion"})
 RULE_PATTERN = re.compile(r'^[A-Za-z0-9_.]+$')
+SKIP_REASONS = frozenset({"too_many_files"})
 
 REPORT_FOOTER = """
 ---
@@ -72,12 +73,13 @@ def validate(data: object) -> list:
     if not isinstance(data, dict):
         return ["root must be an object"]
 
-    allowed_keys = {"summary", "issues"}
+    allowed_keys = {"summary", "issues", "skipped"}
     extra = set(data.keys()) - allowed_keys
     if extra:
         errors.append(f"unexpected top-level keys: {extra}")
-    if not set(data.keys()) >= allowed_keys:
-        errors.append(f"missing top-level keys: {allowed_keys - set(data.keys())}")
+    required_keys = {"summary", "issues"}
+    if not set(data.keys()) >= required_keys:
+        errors.append(f"missing top-level keys: {required_keys - set(data.keys())}")
     if errors:
         return errors
 
@@ -156,6 +158,25 @@ def validate(data: object) -> list:
         if summary["suggestions"] != counts["suggestion"]:
             errors.append(f"summary.suggestions ({summary['suggestions']}) != actual suggestion count ({counts['suggestion']})")
 
+    skipped = data.get("skipped")
+    if skipped is not None:
+        if not isinstance(skipped, dict):
+            errors.append("skipped must be an object")
+            return errors
+
+        skipped_keys = {"reason", "file_count", "max_files"}
+        if set(skipped.keys()) != skipped_keys:
+            errors.append(f"skipped keys must be exactly {skipped_keys}, got {set(skipped.keys())}")
+            return errors
+
+        if skipped["reason"] not in SKIP_REASONS:
+            errors.append(f"skipped.reason must be one of {SKIP_REASONS}, got {skipped['reason']!r}")
+
+        for key in ("file_count", "max_files"):
+            value = skipped[key]
+            if not isinstance(value, int) or value < 0:
+                errors.append(f"skipped.{key} must be a non-negative integer, got {value!r}")
+
     return errors
 
 
@@ -183,6 +204,16 @@ def format_line_link(path: str, line: int, repo: str, pr: str) -> str:
 
 def render(data: dict, repo: str, pr: str) -> str:
     """Render validated JSON data into the markdown report."""
+    skipped = data.get("skipped")
+    if skipped:
+        file_count = skipped["file_count"]
+        max_files = skipped["max_files"]
+        return (
+            "## ⚪ Vale Linting Results\n\n"
+            f"**Skipped:** Vale did not run because this PR touched {file_count} files, which is more than the configured limit of {max_files}.\n"
+            + REPORT_FOOTER
+        )
+
     # Group issues by severity
     groups: dict = {"error": [], "warning": [], "suggestion": []}
     for issue in data["issues"]:

--- a/report/test_render_report.py
+++ b/report/test_render_report.py
@@ -18,7 +18,7 @@ sys.path.insert(0, os.path.dirname(__file__))
 import render_report  # noqa: E402
 
 
-def _valid_data(issues=None):
+def _valid_data(issues=None, skipped=None):
     """Return a minimal valid vale_results.json structure."""
     if issues is None:
         issues = [
@@ -40,6 +40,7 @@ def _valid_data(issues=None):
             "suggestions": counts["suggestion"],
         },
         "issues": issues,
+        **({"skipped": skipped} if skipped is not None else {}),
     }
 
 
@@ -68,6 +69,13 @@ class TestValidation(unittest.TestCase):
         data["extra"] = "bad"
         errors = render_report.validate(data)
         self.assertTrue(any("unexpected top-level keys" in e for e in errors))
+
+    def test_valid_skipped_payload_passes(self):
+        data = _valid_data(
+            issues=[],
+            skipped={"reason": "too_many_files", "file_count": 31, "max_files": 30},
+        )
+        self.assertEqual(render_report.validate(data), [])
 
     def test_summary_wrong_type(self):
         data = _valid_data()
@@ -170,6 +178,14 @@ class TestValidation(unittest.TestCase):
         errors = render_report.validate(data)
         self.assertTrue(any("summary.errors" in e for e in errors))
 
+    def test_invalid_skipped_reason(self):
+        data = _valid_data(
+            issues=[],
+            skipped={"reason": "something_else", "file_count": 31, "max_files": 30},
+        )
+        errors = render_report.validate(data)
+        self.assertTrue(any("skipped.reason" in e for e in errors))
+
 
 # ---------------------------------------------------------------------------
 # Sanitisation tests
@@ -226,6 +242,16 @@ class TestRendering(unittest.TestCase):
         report = render_report.render(data, "owner/repo", "1")
         self.assertIn("No issues found", report)
         self.assertIn("Vale Linting Results", report)
+
+    def test_skipped_report_renders(self):
+        data = _valid_data(
+            issues=[],
+            skipped={"reason": "too_many_files", "file_count": 31, "max_files": 30},
+        )
+        report = render_report.render(data, "owner/repo", "1")
+        self.assertIn("Skipped", report)
+        self.assertIn("31 files", report)
+        self.assertIn("configured limit of 30", report)
 
     def test_single_error_renders(self):
         data = _valid_data()


### PR DESCRIPTION
## Summary
- Skip Vale when the selected markdown file count exceeds a configurable `max_files` threshold so very large PRs do not fail before linting starts.
- Run Vale in bounded batches and merge the JSON output so large file lists do not hit shell argument length limits.
- Add unit and workflow coverage for the new batching and skip behavior, and document the new action input.

## Test plan
- [x] `python3 -m unittest lint/test_run_vale.py -v`
- [x] `python3 -m unittest report/test_render_report.py -v`
- [ ] Run the GitHub Actions workflow end to end.


Made with [Cursor](https://cursor.com)