### PR TITLE
Add DirectionalLanguage rule

### DIFF
--- a/styles/Elastic/DirectionalLanguage.yml
+++ b/styles/Elastic/DirectionalLanguage.yml
@@ -1,0 +1,37 @@
+extends: substitution
+message: "Don't use directional language. Use '%s' instead of '%s'."
+link: https://www.elastic.co/docs/contribute-docs/style-guide/accessibility
+ignorecase: true
+level: warning
+action:
+  name: replace
+swap:
+  # "below" — document forward references
+  '(?:as )?shown below':  'in the following example'
+  'outlined below':       'in the following section'
+  'listed below':         'in the following section'
+  'described below':      'in the following section'
+  'the below example':    'the following example'
+  'in the below example': 'in the following example'
+  'the below steps':      'the following steps'
+  'the below options':    'the following options'
+  'the below (?:table|section|figure|diagram|image|screenshot|chart|list|code|configuration|query|command)s?': 'the following [element]'
+
+  # "above" — document back-references
+  '(?:as )?shown above':  'in the preceding example'
+  'outlined above':       'in the preceding section'
+  'listed above':         'in the preceding section'
+  'described above':      'earlier on this page'
+  'mentioned above':      'earlier on this page'
+  'as mentioned above':   'as described earlier'
+  'noted above':          'earlier on this page'
+  'the above (?:table|section|figure|diagram|image|screenshot|chart|list|code|configuration|query|command)s?': 'the preceding [element]'
+
+  # UI position — left/right
+  'to the (?:left|right) of':        'the label of the element'
+  'on the (?:left|right)(?: side)?': 'the label of the element'
+  'in the (?:left|right)(?: side)?': 'the label of the element'
+  '(?:left|right) side of the page': 'the label of the element'
+  'left-hand side':                  'the label of the element'
+  'right-hand side':                 'the label of the element'
+  'scroll (?:left|right)':           'the label of the element or action'

--- a/styles/Elastic/DirectionalLanguage.yml
+++ b/styles/Elastic/DirectionalLanguage.yml
@@ -6,26 +6,52 @@ level: warning
 action:
   name: replace
 swap:
-  # "below" — document forward references
-  '(?:as )?shown below':  'in the following example'
-  'outlined below':       'in the following section'
-  'listed below':         'in the following section'
-  'described below':      'in the following section'
+  # "below" — document forward references (verb + below)
+  '(?:as )?shown below':       'in the following example'
+  'outlined below':            'in the following section'
+  'listed below':              'in the following section'
+  'described below':           'in the following section'
+  '(?:as )?defined below':     'in the following section'
+  '(?:as )?configured below':  'in the following section'
+  '(?:as )?detailed below':    'in the following section'
+  '(?:as )?specified below':   'in the following section'
+  '(?:as )?provided below':    'in the following section'
+  '(?:as )?discussed below':   'in the following section'
+  '(?:as )?explained below':   'in the following section'
+
+  # "below" — document forward references (the below + noun)
   'the below example':    'the following example'
   'in the below example': 'in the following example'
   'the below steps':      'the following steps'
   'the below options':    'the following options'
   'the below (?:table|section|figure|diagram|image|screenshot|chart|list|code|configuration|query|command)s?': 'the following [element]'
 
-  # "above" — document back-references
-  '(?:as )?shown above':  'in the preceding example'
-  'outlined above':       'in the preceding section'
-  'listed above':         'in the preceding section'
-  'described above':      'earlier on this page'
-  'mentioned above':      'earlier on this page'
-  'as mentioned above':   'as described earlier'
-  'noted above':          'earlier on this page'
+  # "below" — document forward references (noun + below)
+  '(?:the |this )?(?:table|section|figure|diagram|example|screenshot|chart|steps?|commands?|code) below': 'the following [element]'
+  'in (?:the |this )?(?:table|section|figure|diagram|example|screenshot|chart) below':                    'in the following [element]'
+
+  # "above" — document back-references (verb + above)
+  '(?:as )?shown above':       'in the preceding example'
+  'outlined above':            'in the preceding section'
+  'listed above':              'in the preceding section'
+  'described above':           'earlier on this page'
+  'mentioned above':           'earlier on this page'
+  'as mentioned above':        'as described earlier'
+  'noted above':               'earlier on this page'
+  '(?:as )?defined above':     'earlier on this page'
+  '(?:as )?configured above':  'earlier on this page'
+  '(?:as )?detailed above':    'earlier on this page'
+  '(?:as )?specified above':   'earlier on this page'
+  '(?:as )?provided above':    'earlier on this page'
+  '(?:as )?discussed above':   'earlier on this page'
+  '(?:as )?explained above':   'earlier on this page'
+
+  # "above" — document back-references (the above + noun)
   'the above (?:table|section|figure|diagram|image|screenshot|chart|list|code|configuration|query|command)s?': 'the preceding [element]'
+
+  # "above" — document back-references (noun + above)
+  '(?:the |this )?(?:table|section|figure|diagram|example|screenshot|chart|steps?|commands?|code) above': 'the preceding [element]'
+  'in (?:the |this )?(?:table|section|figure|diagram|example|screenshot|chart) above':                    'in the preceding [element]'
 
   # UI position — left/right
   'to the (?:left|right) of':        'the label of the element'


### PR DESCRIPTION
## Summary

Adds a new \`Elastic.DirectionalLanguage\` Vale rule that flags directional language in documentation.

Directional references like *above*, *below*, *to the left*, *to the right* are problematic because:
- Screen readers don't have a concept of spatial position in a document
- RTL languages reverse left/right
- Content reordering breaks document-position references

The rule uses \`substitution\` type so each matched pattern gets a specific, actionable suggestion rather than a generic message.

### Patterns covered

**Document forward references (below → following)**
- Verb + below: \`listed below\`, \`outlined below\`, \`shown below\`, \`described below\`, \`defined below\`, \`configured below\`, \`detailed below\`, \`specified below\`, \`provided below\`, \`discussed below\`, \`explained below\`
- Pre-noun: \`the below example / steps / options / [element]\`, \`in the below example\`
- Post-noun: \`the table/section/figure/diagram/example/screenshot/chart/steps/command/code below\`

**Document back-references (above → preceding / earlier)**
- Verb + above: \`listed above\`, \`outlined above\`, \`shown above\`, \`described above\`, \`mentioned above\`, \`noted above\`, \`defined above\`, \`configured above\`, \`detailed above\`, \`specified above\`, \`provided above\`, \`discussed above\`, \`explained above\`
- Pre-noun: \`the above [element]\`
- Post-noun: \`the table/section/figure/diagram/example/screenshot/chart/steps/command/code above\`

**UI position (left/right → element label)**
- \`to the left/right of\`, \`on the left/right\`, \`in the left/right\`
- \`left-hand side\`, \`right-hand side\`, \`left/right side of the page\`
- \`scroll left/right\`

> **Note on false positives:** The \`[noun] above/below\` patterns are intentionally limited to doc-structure nouns (table, section, figure, example, screenshot, chart, steps, command, code). Words like \`value\`, \`option\`, \`setting\`, and \`configuration\` are excluded to avoid false positives in threshold contexts (e.g., "values above the limit").

### Example output

\`\`\`
warning  Don't use directional language. Use 'in the following section' instead of 'listed below'.
warning  Don't use directional language. Use 'the following [element]' instead of 'the chart below'.
warning  Don't use directional language. Use 'in the preceding [element]' instead of 'in the table above'.
warning  Don't use directional language. Use 'as described earlier' instead of 'as mentioned above'.
warning  Don't use directional language. Use 'the label of the element' instead of 'to the right of'.
warning  Don't use directional language. Use 'the label of the element or action' instead of 'scroll right'.
\`\`\`

### Reference

- [Google developer style guide — Write accessible documentation](https://developers.google.com/style/accessibility#document-rendering)