### PR TITLE
Updates rules to reduce false positives (word choice, Latinisms, wordiness) 

### DIFF
--- a/styles/Elastic/Latinisms.yml
+++ b/styles/Elastic/Latinisms.yml
@@ -10,7 +10,6 @@ swap:
   '\b(ie|i\.e)\b': that is
   '\bad-hoc\b': if needed
   '\bad hoc\b': if needed
-  '\bvia\b': using
   '\bvice versa\b': and the reverse
   '\bvs\b': versus
   '(?<!/)\betc\b': and so on

--- a/styles/Elastic/WordChoice.yml
+++ b/styles/Elastic/WordChoice.yml
@@ -29,7 +29,6 @@ swap:
   may: "can, might"
   mute: "turn off, silence"
   sanity check: "review"
-  '\bsee(?=\s+(?:the|our|this)\b|\s+\[)': "refer to (if it's a document), view (if it's a UI element)"
   simple: "efficient, basic"
   simply: "efficiently"
   skin-toned: "dark brown, cream, beige"

--- a/styles/Elastic/Wordiness.yml
+++ b/styles/Elastic/Wordiness.yml
@@ -128,7 +128,6 @@ swap:
   with the exception of: except for
   provides the opportunity: allows
   there a number of: there are several
-  since: because
   the minute you: when you
   watch the following clip: watch the following tutorial
   don't fall into the habit: we recommend, we encourage


### PR DESCRIPTION
## Summary

Addresses feedback in #116 by removing Vale rules that had scope issues or produced false positives. Happy to discuss any of the following further if anyone disagrees. 

**Changes:**
- **Removed `since: because`** from `Wordiness.yml` — "since" isn't wordy; the concern is ambiguity between temporal and causal senses, which the pattern can't distinguish. Suggestions like "because version 8.0" are incorrect.
- **Removed `see` pattern** from `WordChoice.yml` — "view" has the same sensory connotation as "see." WCAG's concern is about sensory-dependent instructions for identifying UI elements, not conventional cross-reference language.
- **Removed `via: using`** from `Latinisms.yml` — "via" is a fully naturalized English word, not a Latin abbreviation. It carries a distinct meaning ("by way of") that "using" or "through" don't always capture.

**Kept unchanged:**
- `may: "can, might"` — Already suggests both alternatives per Google's style guidance
- Directional language guidance for "above/below" — Encourages precise references like "the following table"

Closes #116

## Test plan

- [ ] Run `vale --config .vale.ini --no-global` against sample files to verify rules no longer fire on removed patterns
- [ ] Confirm remaining rules still function correctly