### PR TITLE
Create StylesPath prior to vale sync

### DIFF
--- a/lint/action.yml
+++ b/lint/action.yml
@@ -157,6 +157,9 @@ runs:
         cat > .vale.ini.temp << 'EOF'
         StylesPath = .vale-styles
 
+        # Vale 3.14.2+ requires StylesPath to exist before `vale sync` (errata-ai/vale#1096)
+        mkdir -p .vale-styles
+        
         Packages = https://github.com/elastic/vale-rules/releases/latest/download/elastic-vale.zip
         EOF
 


### PR DESCRIPTION
This pull request ensures the `.vale-styles` directory exists before running `vale sync`, addressing a requirement introduced in Vale 3.14.2+.

More info: https://github.com/vale-cli/vale/pull/1096