### PR TITLE
Add KibanaChromeTerms substitution rule

### DIFF
--- a/styles/Elastic/KibanaChromeTerms.yml
+++ b/styles/Elastic/KibanaChromeTerms.yml
@@ -1,0 +1,18 @@
+extends: substitution
+message: "Consider using '%s' instead of '%s' when referring to parts of the Kibana chrome."
+link: https://www.elastic.co/docs/contribute-docs/style-guide/ui-writing#naming-kibana-ui-elements
+ignorecase: true
+level: suggestion
+action:
+  name: replace
+swap:
+  main menu: "navigation menu"
+  side navigation: "navigation menu"
+  side nav: "navigation menu"
+  sidenav: "navigation menu"
+  primary navigation: "navigation menu"
+  navbar: "navigation menu"
+  app menu bar: "application menu"
+  app menu: "application menu"
+  app workspace: "workspace"
+  classic navigation: "classic view"


### PR DESCRIPTION
## Summary

MERGE ONLY AFTER https://github.com/elastic/docs-content/pull/6693

Add a new `Elastic.KibanaChromeTerms` substitution rule that suggests the canonical Kibana chrome terms when older or internal variants appear in docs.

Swaps (suggestion level, replace action, `ignorecase: true`):

| Match | Suggestion |
|---|---|
| main menu | navigation menu |
| side navigation | navigation menu |
| side nav | navigation menu |
| sidenav | navigation menu |
| primary navigation | navigation menu |
| navbar | navigation menu |
| app menu bar | application menu |
| app menu | application menu |
| app workspace | workspace |
| classic navigation | classic view |

The rule `link:` points at the new `#naming-kibana-ui-elements` section of the public style guide introduced in elastic/docs-content#6693.

## Dependency

Depends on elastic/docs-content#6693. That PR introduces the **Naming Kibana UI elements** section that this rule's `link:` field targets. Merge that PR first so the link is live before we cut a release containing this rule.

## Test plan

Locally validated with `vale --config .vale.ini --no-global`:

```
3:21   suggestion  Consider using 'navigation menu' instead of 'main menu' ...
4:10   suggestion  Consider using 'navigation menu' instead of 'side navigation' ...
5:9    suggestion  Consider using 'navigation menu' instead of 'side nav' ...
6:11   suggestion  Consider using 'navigation menu' instead of 'sidenav' ...
7:5    suggestion  Consider using 'navigation menu' instead of 'primary navigation' ...
8:5    suggestion  Consider using 'navigation menu' instead of 'navbar' ...
9:11   suggestion  Consider using 'application menu' instead of 'app menu bar' ...
10:10  suggestion  Consider using 'application menu' instead of 'app menu' ...
11:5   suggestion  Consider using 'workspace' instead of 'app workspace' ...
12:11  suggestion  Consider using 'classic view' instead of 'classic navigation' ...
```

Canonical forms ("navigation menu", "application menu", "workspace", "classic view") do not trigger the rule.

- [ ] Reviewer to consider whether to ship this in a follow-up minor release or batch with other rule changes.

Made with [Cursor](https://cursor.com)