### PR TITLE
Fix QuotesPunctuation false positives on applies_to directive JSON

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -10,4 +10,4 @@ Vocab = ElasticTerms, ThirdPartyProducts, TechJargon
 BasedOnStyles = Elastic
 Elastic.Spelling = NO
 BlockIgnores = (?s)<!--.*?-->
-TokenIgnores = % (.*), \*\*(.*), (.*)\*\*, \*\*(.*)\*\*, , <(.*)>, {{(.*)}}, \s*\[[a-zA-Z0-9_.-]+\]
+TokenIgnores = {".*"}, % (.*), \*\*(.*), (.*)\*\*, \*\*(.*)\*\*, , <(.*)>, {{(.*)}}, \s*\[[a-zA-Z0-9_.-]+\]


### PR DESCRIPTION
## Summary

`Elastic.QuotesPunctuation` fires on docs-builder directive-option lines that carry inline JSON, most commonly `:applies_to:`. In `{"stack": "preview 9.5", "serverless": "preview"}`, the substring `"preview 9.5",` (a quoted value followed by a comma) matches the rule token, so writers get a "Place punctuation inside closing quotation marks" warning on structured metadata that has no prose to fix. It recurs on every page using the JSON form of `:applies_to:`, which trains writers to ignore warnings.

## Change

- **`.vale.ini`**: add a `TokenIgnores` entry `{".*"}` so inline JSON maps are excluded from all rules, wherever they appear.

This is a variant of option 2 in the issue, tightened to require a quote after the opening brace so it targets JSON maps specifically:

- It does **not** match MyST roles (`{applies_to}`), substitutions (`{{version}}`), or icon roles (`` {icon}`gear` ``).
- It is scoped to the JSON blob rather than the whole directive line, so real prose in other directive options (`:name:`, `:caption:`, etc.) stays lintable. A line-level `BlockIgnores` on `:key:` lines was considered but rejected because it blinds every rule on the entire line.

## Why not tighten the QuotesPunctuation regex instead

That would need a negative lookahead to distinguish a JSON `"value",` separator from an end-of-clause `"word",`. Vale uses Go's RE2 engine, which has no lookahead, so a clean rule-only fix is not practical. Validation of `applies_to` syntax itself is already handled by docs-builder at build time.

## Verification

Ran locally with `vale --config .vale.ini --no-global`:

- Before: `:applies_to: {"stack": "preview 9.5", ...}` produced a false-positive warning.
- After: no warning on the directive line.
- Regression check: a genuine violation on a normal prose line (`She said "hello world".`) still flags, and prose in other directive options (for example an `eg` Latinism in a `:name:` value) is still caught.

Resolves #148

---

> AI-assisted change — reviewed for accuracy before submitting.

Made with [Cursor](https://cursor.com)