### PR TITLE
Ignore JSON values in directive options

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -9,5 +9,5 @@ Vocab = ElasticTerms, ThirdPartyProducts, TechJargon
 [*.md]
 BasedOnStyles = Elastic
 Elastic.Spelling = NO
-BlockIgnores = (?s)<!--.*?-->
+BlockIgnores = (?s)<!--.*?-->, (?m)^[ \t]*:[A-Za-z][A-Za-z0-9_-]*:[ \t]*\{[ \t]*".*\}[ \t]*$
 TokenIgnores = % (.*), \*\*(.*), (.*)\*\*, \*\*(.*)\*\*, , <(.*)>, {{(.*)}}, \s*\[[a-zA-Z0-9_.-]+\]

--- a/.vale.ini
+++ b/.vale.ini
@@ -9,5 +9,5 @@ Vocab = ElasticTerms, ThirdPartyProducts, TechJargon
 [*.md]
 BasedOnStyles = Elastic
 Elastic.Spelling = NO
-BlockIgnores = (?s)<!--.*?-->, (?m)^[ \t]*:[A-Za-z][A-Za-z0-9_-]*:[ \t]*\{[ \t]*".*\}[ \t]*$
+BlockIgnores = (?s)<!--.*?-->, (?m)^[ \t]*:applies_to:[ \t]*\{[ \t]*".*\}[ \t]*$
 TokenIgnores = % (.*), \*\*(.*), (.*)\*\*, \*\*(.*)\*\*, , <(.*)>, {{(.*)}}, \s*\[[a-zA-Z0-9_.-]+\]


### PR DESCRIPTION
## Summary

- ignore inline JSON only on `:applies_to:` directive-option lines
- support both compact and whitespace-formatted JSON maps
- keep every other directive option and JSON embedded in ordinary prose lintable

This is an alternative to #149. The latest commit narrows the ignore to the metadata field responsible for the reported false positives instead of applying it to all JSON-valued directive options. This avoids suppressing legitimate Vale findings in other directive values. `applies_to` syntax is validated by docs-builder.

## Verification

Tested locally with Vale 3.14.2.

### Targeted regression fixture

```sh
vale --config .vale.ini --no-global --output line /path/to/vale-rules-148-regression.md
```

The fixture covered:

- compact `:applies_to:` JSON
- `:applies_to:` JSON with spaces after `{` and before `}`
- JSON under another directive option, which remains lintable
- prose-valued `:name:` and `:caption:` options
- a normal quotation-punctuation violation
- multiple JSON objects surrounding lintable prose
- the existing HTML-comment ignore

Both `:applies_to:` variants were ignored. All five intentional findings outside `:applies_to:` were reported at their expected locations, and the HTML comment remained ignored.

### All-rules regression file

Ran the modified configuration and the `main` configuration against the untracked `test-all-rules.md` file in the Elastic style-guide repository:

```sh
vale --config .vale.ini --no-global --output line /path/to/test-all-rules.md
```

Both configurations reported 98 findings. Their sorted outputs were identical, confirming that the scoped `:applies_to:` ignore does not change any existing finding in the all-rules fixture. `git diff --check` also passed.

Closes #148