### PR TITLE
Clarify rule messages and severity guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ cd /path/to/elastic-style-guide
 echo "This uses eg, instead of for example." > test.md
 
 # Run Vale using the local configuration
-vale --config=.vale.ini test.md
+vale --config=.vale.ini --no-global test.md
 ```
 
 Vale immediately uses the rules from the local `styles/Elastic/` directory. Any changes you make to rule files are reflected instantly without needing to create a release.
@@ -206,12 +206,22 @@ vim styles/Elastic/Latinisms.yml
 2. Run Vale against a test file:
 
 ```bash
-vale --config=.vale.ini your-test-file.md
+vale --config=.vale.ini --no-global your-test-file.md
 ```
 
 3. Iterate on your changes until the rule works as expected.
 
 The local `.vale.ini` configuration uses `StylesPath = styles`, which points directly to the local directory, so there's no need for releases or package syncing during development.
+
+### Rule authoring guidance
+
+Use rule messages to explain the issue and the next action. Prefer messages that name the matched term with `%s`, suggest a replacement when one is available, and explain context for rules that require judgment.
+
+Use severity levels consistently:
+
+- Use `error` only for content that is structurally broken or unsafe to ship, such as conflict markers.
+- Use `warning` for high-confidence issues with a clear fix, such as spelling, accessibility terms, or blocked word choices.
+- Use `suggestion` for style guidance, tone guidance, or context-dependent advice.
 
 ## Creating releases
 

--- a/styles/Elastic/DontUse.yml
+++ b/styles/Elastic/DontUse.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: "Don't use '%s'."
+message: "Don't use '%s'. Choose a more precise or reader-focused term."
 link: https://www.elastic.co/docs/contribute-docs/style-guide/word-choice
 ignorecase: true
 level: warning

--- a/styles/Elastic/Ellipses.yml
+++ b/styles/Elastic/Ellipses.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: "In general, don't use an ellipsis."
+message: "Use ellipses sparingly. Remove the ellipsis unless it appears in UI text."
 link: https://www.elastic.co/docs/contribute-docs/style-guide/voice-tone#write-like-a-minimalist
 nonword: true
 level: suggestion

--- a/styles/Elastic/Exclamation.yml
+++ b/styles/Elastic/Exclamation.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: "Use exclamation points sparingly. Consider removing the exclamation point."
+message: "Use exclamation points sparingly. Remove the exclamation point unless it appears in UI text."
 link: https://www.elastic.co/docs/contribute-docs/style-guide/voice-tone#tone
 nonword: true
 level: suggestion

--- a/styles/Elastic/FirstPerson.yml
+++ b/styles/Elastic/FirstPerson.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: "Use caution when using first-person pronouns (me, my, mine)."
+message: "Use first-person pronouns sparingly. Rephrase '%s' if the sentence can focus on the user or product instead."
 link: https://www.elastic.co/docs/contribute-docs/style-guide/grammar-spelling#use-singular-first-person-pronouns-sparingly-i-me-my-mine
 ignorecase: true
 level: suggestion

--- a/styles/Elastic/MappedPages.yml
+++ b/styles/Elastic/MappedPages.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: "mapped_pages should only be added or updated in rare scenarios. Talk with your local technical writer before pushing changes to this key."
+message: "Avoid editing mapped_pages unless you are preserving an existing URL mapping. Talk with your local technical writer before changing this key."
 level: warning
 nonword: true
 scope: raw

--- a/styles/Elastic/Semicolons.yml
+++ b/styles/Elastic/Semicolons.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: "Use semicolons judiciously."
+message: "Use semicolons sparingly. Consider splitting the sentence or using a comma or conjunction."
 link: https://www.elastic.co/docs/contribute-docs/style-guide/grammar-spelling#semicolons
 nonword: true
 scope: sentence


### PR DESCRIPTION
## Summary
- Makes several broad Vale rule messages more actionable while preserving existing rule behavior and severity.
- Documents message-writing and severity-level guidance for future rule changes.
- Updates local testing examples to use `--no-global` so contributors test the repo's local rules.

## Test plan
- `vale ls-config --config=.vale.ini --no-global`
- `vale --config=.vale.ini --no-global test-all-rules.md`
- `vale --config=.vale.ini --no-global README.md`


Made with [Cursor](https://cursor.com)