### PR TITLE
Document regex intent in Vale rules

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -9,5 +9,7 @@ Vocab = ElasticTerms, ThirdPartyProducts, TechJargon, GeographicNames
 [*.md]
 BasedOnStyles = Elastic
 Elastic.Spelling = NO
+# Ignore HTML comments and applies_to JSON metadata so rule matches come from rendered prose.
 BlockIgnores = (?s)<!--.*?-->, (?m)^[ \t]*:applies_to:[ \t]*\{[ \t]*".*\}[ \t]*$
+# Ignore common Markdown, MyST, and inline HTML constructs that often contain code-like tokens.
 TokenIgnores = % (.*), \*\*(.*), (.*)\*\*, \*\*(.*)\*\*, , <(.*)>, {{(.*)}}, \s*\[[a-zA-Z0-9_.-]+\]

--- a/styles/Elastic/ConflictMarkers.yml
+++ b/styles/Elastic/ConflictMarkers.yml
@@ -7,6 +7,7 @@ message: "Do not commit Git merge conflict markers in source code."
 action:
   name: remove
 tokens:
+  # Match only full-line Git conflict markers so ordinary angle brackets are not flagged.
   - '^<{7}\s.*$'
   - '^={7}$'
   - '^>{7}\s.*$'

--- a/styles/Elastic/FirstPerson.yml
+++ b/styles/Elastic/FirstPerson.yml
@@ -5,4 +5,6 @@ ignorecase: true
 level: suggestion
 nonword: true
 raw:
+  # Treat hyphens and underscores as identifier characters so cloud region IDs
+  # and slugs like me-central2, my-app, and my_app are not flagged.
   - '(?<![a-zA-Z0-9_-])(me|my|mine)(?![a-zA-Z0-9_-])'

--- a/styles/Elastic/Latinisms.yml
+++ b/styles/Elastic/Latinisms.yml
@@ -12,4 +12,5 @@ swap:
   '\bad hoc\b': if needed
   '\bvice versa\b': and the reverse
   '\bvs\b': versus
+  # Allow URL paths like /etc while still flagging etc in prose.
   '(?<!/)\betc\b': and so on

--- a/styles/Elastic/MenuArrows.yml
+++ b/styles/Elastic/MenuArrows.yml
@@ -10,5 +10,6 @@ action:
     - '\s*(?:=>|>)\s*'
     - ' → '
 tokens:
+  # Match bare => everywhere, but require words around > so comparisons and markup are less noisy.
   - "=>"
   - '[A-Za-z]{3,}\s>\s[A-Za-z]{3,}'

--- a/styles/Elastic/MenuArrowsBold.yml
+++ b/styles/Elastic/MenuArrowsBold.yml
@@ -11,5 +11,7 @@ action:
     - '\s*(?:=>|>)\s*'
     - ' → '
 tokens:
+  # Match bold menu paths on one Markdown line while avoiding code spans and indented code.
   - '^[ \t]{0,3}[^ \t`\n][^`\n]*\*\*[^*`\n]{2,}\s(?:>|=>)\s[^*`\n]{2,}\*\*[^`\n]*$'
+  # Match the common **Menu** > **Item** form without reaching across lines.
   - '^[ \t]{0,3}[^ \t`\n][^`\n]*\*\*[A-Za-z]{2,}(?:\s[A-Za-z]{2,})*\*\*\s(?:>|=>)\s\*\*[A-Za-z]{2,}(?:\s[A-Za-z]{2,})*\*\*[^`\n]*$'

--- a/styles/Elastic/Wordiness.yml
+++ b/styles/Elastic/Wordiness.yml
@@ -18,6 +18,7 @@ swap:
   a myriad of: myriad
   adversely impact: hurt
   all across: across
+  # Preserve the idioms that have separate, more specific replacements below.
   all of (?!a sudden|these): all
   all of a sudden: suddenly
   all of these: these
@@ -80,6 +81,7 @@ swap:
   in a careful manner: carefully
   in a thoughtful manner: thoughtfully
   in a timely manner: timely
+  # Flag "in addition" on its own, but leave "in addition to" for context-specific editing.
   in addition(?!\s+to\b): also
   in an effort to: to
   in between: between


### PR DESCRIPTION
## Summary
- Adds comments for regex patterns whose boundaries or exclusions are easy to break during cleanup.
- Documents false-positive guards in first-person, Latinisms, wordiness, menu-arrow, conflict-marker, and root ignore patterns.
- Keeps rule behavior unchanged.

## Test plan
- `vale ls-config --config=.vale.ini --no-global`
- `vale --config=.vale.ini --no-global test-all-rules.md`


Made with [Cursor](https://cursor.com)