### PR TITLE
Add Vale rule regression tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test Vale rules
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  vale-rule-tests:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+
+      - name: Install Vale
+        env:
+          VALE_VERSION: 3.17.1
+        run: |
+          curl -fsSL "https://github.com/errata-ai/vale/releases/download/v${VALE_VERSION}/vale_${VALE_VERSION}_Linux_64-bit.tar.gz" -o vale.tar.gz
+          tar -xzf vale.tar.gz vale
+          sudo mv vale /usr/local/bin/vale
+          vale --version
+
+      - name: Run rule regression tests
+        run: python3 rule-tests/run_rule_tests.py

--- a/README.md
+++ b/README.md
@@ -213,6 +213,16 @@ vale --config=.vale.ini --no-global your-test-file.md
 
 The local `.vale.ini` configuration uses `StylesPath = styles`, which points directly to the local directory, so there's no need for releases or package syncing during development.
 
+### Running regression tests
+
+Run the focused regression tests before changing rule matching behavior:
+
+```bash
+python3 rule-tests/run_rule_tests.py
+```
+
+These tests assert exact matches for rules with known false-positive risks.
+
 ### Rule authoring guidance
 
 Use rule messages to explain the issue and the next action. Prefer messages that name the matched term with `%s`, suggest a replacement when one is available, and explain context for rules that require judgment.

--- a/rule-tests/fixtures/first-person.md
+++ b/rule-tests/fixtures/first-person.md
@@ -1,0 +1,7 @@
+my-app should not trigger the first-person rule.
+My cluster uses autoscaling.
+Give me the deployment ID.
+This setup is mine.
+The my_app variable appears in code-like text.
+Acme appears as part of a word.
+me my mine

--- a/rule-tests/fixtures/spelling-cloud-regions.md
+++ b/rule-tests/fixtures/spelling-cloud-regions.md
@@ -1,0 +1,4 @@
+Sao Paulo and Tel Aviv are available regions.
+Gävle, Eemshaven, Johannesburg, Mumbai, Pune, Zurich, Bahrain, and Jurong are region names.
+australiaeast, eastus, eastus2, northeurope, southeastasia, swedencentral, and westus2 are Azure region IDs.
+This line contains Gatewaty as a control misspelling.

--- a/rule-tests/run_rule_tests.py
+++ b/rule-tests/run_rule_tests.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Run focused regression tests for local Vale rules."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+FIXTURES = REPO_ROOT / "rule-tests" / "fixtures"
+
+
+def run_vale(config: Path, fixture: Path) -> list[dict]:
+    result = subprocess.run(
+        [
+            "vale",
+            f"--config={config}",
+            "--no-global",
+            "--output=JSON",
+            str(fixture),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+    if result.returncode not in (0, 1):
+        print(result.stdout, end="")
+        print(result.stderr, end="", file=sys.stderr)
+        raise AssertionError(f"Vale failed for {fixture} with exit code {result.returncode}.")
+
+    if not result.stdout.strip():
+        return []
+
+    output = json.loads(result.stdout)
+    return output.get(str(fixture), [])
+
+
+def assert_rule_matches(
+    name: str,
+    alerts: list[dict],
+    rule: str,
+    expected: list[tuple[int, str]],
+) -> None:
+    actual = [(alert["Line"], alert["Match"]) for alert in alerts if alert["Check"] == rule]
+
+    if actual != expected:
+        raise AssertionError(
+            f"{name} expected {rule} matches {expected}, but got {actual}."
+        )
+
+    print(f"ok {name}")
+
+
+def spelling_config(tmp_dir: Path) -> Path:
+    config = tmp_dir / "spelling.vale.ini"
+    config.write_text(
+        "\n".join(
+            [
+                f"StylesPath = {REPO_ROOT / 'styles'}",
+                "MinAlertLevel = suggestion",
+                "Vocab = ElasticTerms, ThirdPartyProducts, TechJargon, GeographicNames",
+                "",
+                "[*.md]",
+                "BasedOnStyles = Elastic",
+                "Elastic.Spelling = YES",
+                "",
+            ]
+        ),
+        encoding="utf-8",
+    )
+    return config
+
+
+def main() -> int:
+    first_person_alerts = run_vale(REPO_ROOT / ".vale.ini", FIXTURES / "first-person.md")
+    assert_rule_matches(
+        "first-person boundaries",
+        first_person_alerts,
+        "Elastic.FirstPerson",
+        [
+            (2, "My"),
+            (3, "me"),
+            (4, "mine"),
+            (7, "me"),
+            (7, "my"),
+            (7, "mine"),
+        ],
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        spelling_alerts = run_vale(
+            spelling_config(Path(tmp)),
+            FIXTURES / "spelling-cloud-regions.md",
+        )
+
+    assert_rule_matches(
+        "cloud-region spelling vocabulary",
+        spelling_alerts,
+        "Elastic.Spelling",
+        [(4, "Gatewaty")],
+    )
+
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except AssertionError as error:
+        print(f"not ok {error}", file=sys.stderr)
+        raise SystemExit(1)


### PR DESCRIPTION
## Summary
- Adds focused fixtures for first-person boundary behavior and cloud-region spelling vocabulary.
- Adds a Python regression runner that asserts exact Vale rule matches from JSON output.
- Adds a PR and main-branch workflow that installs Vale and runs the regression tests.

## Test plan
- `python3 rule-tests/run_rule_tests.py`
- `vale ls-config --config=.vale.ini --no-global`
- `vale --config=.vale.ini --no-global README.md`


Made with [Cursor](https://cursor.com)