### PR TITLE
Draft: Intentionally break first-person regression test

### DIFF
--- a/styles/Elastic/FirstPerson.yml
+++ b/styles/Elastic/FirstPerson.yml
@@ -7,4 +7,4 @@ nonword: true
 raw:
   # Treat hyphens and underscores as identifier characters so cloud region IDs
   # and slugs like me-central2, my-app, and my_app are not flagged.
-  - '(?<![a-zA-Z0-9_-])(me|my|mine)(?![a-zA-Z0-9_-])'
+  - '(?<![a-zA-Z0-9-])(me|my|mine)(?![a-zA-Z0-9-])'


### PR DESCRIPTION
## Summary
- Intentionally removes `_` from the `Elastic.FirstPerson` boundary guard.
- This should make the new regression test fail by flagging `my` in `my_app`.

## Test plan
- Expected failure: `python3 rule-tests/run_rule_tests.py`

Local failure observed:

```text
not ok first-person boundaries expected Elastic.FirstPerson matches [(2, 'My'), (3, 'me'), (4, 'mine'), (7, 'me'), (7, 'my'), (7, 'mine')], but got [(2, 'My'), (3, 'me'), (4, 'mine'), (5, 'my'), (7, 'me'), (7, 'my'), (7, 'mine')].
```


Made with [Cursor](https://cursor.com)